### PR TITLE
Version 0.4.2

### DIFF
--- a/Assistants/Model.php
+++ b/Assistants/Model.php
@@ -303,8 +303,6 @@ class Model
     
     private function finishRequest($result = array('content'=>'', 'status'=>200, 'statusText'=>null))
     {
-        if (isset( $result['content'])  )
-            echo $result['content'];  
                     
         $code = 0;
         if (isset( $result['status']) ){
@@ -319,6 +317,9 @@ class Model
 
         $protocol = (isset($_SERVER['SERVER_PROTOCOL']) ? $_SERVER['SERVER_PROTOCOL'] : 'HTTP/1.0');
         header($protocol . ' ' . $code . (isset($statusText)?$statusText:''));
+        
+        if (isset( $result['content'])  )
+            echo $result['content'];  
     }
     
     /**

--- a/Assistants/Request.php
+++ b/Assistants/Request.php
@@ -85,8 +85,22 @@ class Request
     {
         $begin = microtime(true);
         
+        $configData = null;
+        $confFile = dirname(__FILE__).'/config.ini';
+        if (file_exists($confFile)){
+            $configData =  parse_ini_file($confFile,TRUE);
+        }
+        
+        // nun soll eine globale URL erkannt werden und in eine lokale überführt werden (wenn möglich)
+        if (isset($configData['PL']['urlExtern']) && isset($configData['PL']['url'])){
+            if (strpos($target,$configData['PL']['urlExtern'].'/')===0){
+                // es wurde eine globale URL erkannt, welche zu einer lokalen umgewandelt werden kann
+                $target = $configData['PL']['url'].substr($target,strlen($configData['PL']['urlExtern']));
+            }
+        }
+
         $done = false;
-        if (!CConfig::$onload && strpos($target,'http://localhost/')===0 && file_exists(dirname(__FILE__) . '/request_cconfig.json')){
+        if (!CConfig::$onload && isset($configData['PL']['url']) && strpos($target,$configData['PL']['url'].'/')===0 && file_exists(dirname(__FILE__) . '/request_cconfig.json')){
             if (self::$components===null){
                 self::$components=CConfig::loadStaticConfig('','',dirname(__FILE__),'request_cconfig.json');
             }
@@ -94,20 +108,29 @@ class Request
             $coms = self::$components->getLinks();
             if ($coms!=null){      
                 if (!is_array($coms)) $coms = array($coms);
-                
-                $e = strlen(rtrim($_SERVER['DOCUMENT_ROOT'],'/'));
-                $f = substr(str_replace("\\","/",dirname(__FILE__)),$e);
-                $g = substr(str_replace("\\","/",$_SERVER['SCRIPT_FILENAME']),$e);
 
-                $a=0;
-                for (;$a<strlen($g) && $a<strlen($f) && $f[$a] == $g[$a];$a++){}
-                $h = substr(str_replace("\\","/",$_SERVER['PHP_SELF']),0,$a-1);
                 foreach ($coms as $com){
                     if ($com->getPrefix() === null || $com->getLocalPath()==null || $com->getClassFile()==null || $com->getClassName()==null) {
                         Logger::Log('nodata: '.$method.' '.$target, LogLevel::DEBUG, false, dirname(__FILE__) . '/../calls.log');
                         continue;
                     }
-                    $url = 'http://localhost'.$h.'/'.$com->getLocalPath();
+                    
+                    // die Länge des Serverpfades Bsp.: 15
+                    $e = strlen(rtrim($_SERVER['DOCUMENT_ROOT'],'/'));
+                    
+                    $f = substr(str_replace("\\","/",dirname(__FILE__)),$e);
+                    $g = substr(str_replace("\\","/",$_SERVER['SCRIPT_FILENAME']),$e);
+
+                    $a=0;
+                    for (;$a<strlen($g) && $a<strlen($f) && $f[$a] == $g[$a];$a++){}
+                    
+                    // der Unterordner. Bsp.: uebungsplattform/
+                    $h = substr(str_replace("\\","/",$_SERVER['PHP_SELF']),0,$a-1);
+                    
+                    // ermittelt den Anfang der lokalen URL (ohne Unterordner). Bsp.: http://localhost
+                    $basePath = substr($configData['PL']['url'], 0,strlen($configData['PL']['url'])-strlen($h));
+
+                    $url = $configData['PL']['url'].'/'.$com->getLocalPath();
 
                     if (strpos($target,$url.'/')===0){
                         $result = array();
@@ -172,11 +195,8 @@ class Request
                             $oldRequestURI = $_SERVER['REQUEST_URI'];
                             $oldScriptName = $_SERVER['SCRIPT_NAME'];
                             ///$oldRedirectURL = $_SERVER['REDIRECT_URL'];
-                            ///echo "old: ".$_SERVER['REQUEST_URI']."\n";
-                            $_SERVER['REQUEST_URI'] = substr($target,strlen('http://localhost/')-1);//$tar.$add;
-                            ///$_SERVER['REDIRECT_URL']= substr($target,strlen('http://localhost/')-1);
-                            ///echo "mein: ".substr($target,strlen('http://localhost/')-1)."\n";
-                            $_SERVER['SCRIPT_NAME'] = $h.'/'.$com->getLocalPath().'/'.$com->getClassFile(); //$tar;
+                            $_SERVER['REQUEST_URI'] = substr($target,strlen($basePath.'/')-1);
+                            $_SERVER['SCRIPT_NAME'] = $h.'/'.$com->getLocalPath().'/'.$com->getClassFile();
                             $_SERVER['QUERY_STRING']='';
                             $_SERVER['REQUEST_METHOD']=$method;
                             \Slim\Environment::mock($args);

--- a/DB/CControl/CControl.php
+++ b/DB/CControl/CControl.php
@@ -771,18 +771,12 @@ class CControl
                 $object = Component::decodeComponent( json_encode( $object ) );
                 
                 // prüfen, welche Komponente auf diesem Server ist
+                // es werden nur "lokale" Komponenten initialisiert
                 if (strpos($object->getAddress().'/', $data['PL']['urlExtern'].'/')===false) continue;
 
-                $object->setAddress($data['PL']['url'].substr($object->getAddress(),strlen($data['PL']['urlExtern'])));
-                $links = $object->getLinks();
-                foreach($links as &$link){
-                    if (strpos($link->getAddress().'/', $data['PL']['urlExtern'].'/')===false) continue;
-                    $link->setAddress($data['PL']['url'].substr($link->getAddress(),strlen($data['PL']['urlExtern'])));
-                }
-                $object->setLinks($links);
-                
+                $URL = $object->getAddress();//$data['PL']['url'].substr($object->getAddress(),strlen($data['PL']['urlExtern']));
                 $result = Request_CreateRequest::createPost( 
-                                                            $object->getAddress( ) . '/control',
+                                                            $URL . '/control',
                                                             array( ),
                                                             Component::encodeComponent( $object )
                                                             );
@@ -1017,8 +1011,19 @@ class CControl
 
                 $this->_app->response->setStatus( 409 );
                 $this->_app->stop();
-            }       
+            }   
+            
+            $file2 = dirname(__FILE__).'/../../Assistants/config.ini';
+            if (!@file_put_contents($file2,$text)){
+                Logger::Log( 
+                            'POST AddPlatform failed, config.ini no access',
+                            LogLevel::ERROR
+                            );
 
+                $this->_app->response->setStatus( 409 );
+                $this->_app->stop();
+            }   
+            
             // starts a query
             ob_start();
             eval("?>" .  file_get_contents( dirname(__FILE__).'/Sql/AddPlatform.sql' ));

--- a/DB/DBMarking/Sql/procedures/GetAllMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetAllMarkings.sql
@@ -50,7 +50,7 @@ from
         left join
     File F ON (F.F_id = M.F_id_file)
         left join 
-    File F2 ON (F2.F_id = S.F_id_file);");
+    File F2 ON (F2.F_id = S.F_id_file) order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetCourseMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetCourseMarkings.sql
@@ -54,7 +54,7 @@ from
         left join 
     File F2 ON (F2.F_id = S.F_id_file)
 where
-    ES.C_id = '",courseid,"';");
+    ES.C_id = '",courseid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetCourseUserGroupMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetCourseUserGroupMarkings.sql
@@ -57,7 +57,7 @@ from
         left join
     File F ON (F.F_id = M.F_id_file)
         left join 
-    File F2 ON (F2.F_id = S.F_id_file)");
+    File F2 ON (F2.F_id = S.F_id_file) order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetExerciseMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetExerciseMarkings.sql
@@ -52,7 +52,7 @@ from
         left join 
     File F2 ON (F2.F_id = S.F_id_file)
 where
-    M.E_id = '",eid,"';");
+    M.E_id = '",eid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetSheetMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetSheetMarkings.sql
@@ -52,7 +52,7 @@ from
         left join 
     File F2 ON (F2.F_id = S.F_id_file)
 where
-    M.ES_id = '",esid,"';");
+    M.ES_id = '",esid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetSubmissionMarking.sql
+++ b/DB/DBMarking/Sql/procedures/GetSubmissionMarking.sql
@@ -52,7 +52,7 @@ from
         left join 
     File F2 ON (F2.F_id = S.F_id_file)
 where
-    M.S_id = '",suid,"';");
+    M.S_id = '",suid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetTutorCourseMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetTutorCourseMarkings.sql
@@ -54,7 +54,7 @@ from
         left join 
     File F2 ON (F2.F_id = S.F_id_file)
 where
-    M.U_id_tutor = '",userid,"';");
+    M.U_id_tutor = '",userid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetTutorExerciseMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetTutorExerciseMarkings.sql
@@ -53,7 +53,7 @@ from
     File F2 ON (F2.F_id = S.F_id_file)
 where
     M.E_id = '",eid,"'
-        and M.U_id_tutor = '",userid,"';");
+        and M.U_id_tutor = '",userid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetTutorSheetMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetTutorSheetMarkings.sql
@@ -53,7 +53,7 @@ from
     File F2 ON (F2.F_id = S.F_id_file)
 where
     M.ES_id = '",esid,"'
-        and M.U_id_tutor = '",userid,"';");
+        and M.U_id_tutor = '",userid,"' order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/DB/DBMarking/Sql/procedures/GetUserGroupMarkings.sql
+++ b/DB/DBMarking/Sql/procedures/GetUserGroupMarkings.sql
@@ -57,7 +57,7 @@ from
         left join
     File F ON (F.F_id = M.F_id_file)
         left join 
-    File F2 ON (F2.F_id = S.F_id_file);");
+    File F2 ON (F2.F_id = S.F_id_file) order by M_id;");
 PREPARE stmt1 FROM @s;
 EXECUTE stmt1;
 DEALLOCATE PREPARE stmt1;

--- a/FS/FSBinder/FSBinder.php
+++ b/FS/FSBinder/FSBinder.php
@@ -131,7 +131,8 @@ class FSBinder
              file_exists( $this->config['DIR']['files'].'/'.$filePath ) ){
 
             // the file was found
-            Model::header('Content-Type','application/octet-stream');
+            $mime = MimeReader::get_mime($this->config['DIR']['files'].'/'.$filePath);
+            Model::header('Content-Type',$mime);
             Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');

--- a/FS/FSBinder/FSBinder.php
+++ b/FS/FSBinder/FSBinder.php
@@ -133,7 +133,7 @@ class FSBinder
             // the file was found
             $mime = MimeReader::get_mime($this->config['DIR']['files'].'/'.$filePath);
             Model::header('Content-Type',$mime);
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');
             readfile( $this->config['DIR']['files'].'/'.$filePath );

--- a/FS/FSCsv/FSCsv.php
+++ b/FS/FSCsv/FSCsv.php
@@ -102,7 +102,7 @@ class FSCsv
         if (isset($params['filename'])){
             
             Model::header('Content-Type','text/csv');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");
             Model::header('Accept-Ranges','none');
             
             if (isset($result)){
@@ -155,7 +155,7 @@ class FSCsv
 
             // the file was found
             Model::header('Content-Type','text/csv');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");   
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");   
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));  
             Model::header('Accept-Ranges','none'); 
                                             

--- a/FS/FSFile/FSFile.php
+++ b/FS/FSFile/FSFile.php
@@ -156,7 +156,7 @@ class FSFile
             // the file was found
             $mime = MimeReader::get_mime($this->config['DIR']['files'].'/'.$filePath);
             Model::header('Content-Type',$mime);
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');
             readfile( $this->config['DIR']['files'].'/'.$filePath );

--- a/FS/FSFile/FSFile.php
+++ b/FS/FSFile/FSFile.php
@@ -154,7 +154,8 @@ class FSFile
              file_exists( $this->config['DIR']['files'].'/'.$filePath ) ){
 
             // the file was found
-            Model::header('Content-Type','application/octet-stream');
+            $mime = MimeReader::get_mime($this->config['DIR']['files'].'/'.$filePath);
+            Model::header('Content-Type',$mime);
             Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');

--- a/FS/FSPdf/FSPdf.php
+++ b/FS/FSPdf/FSPdf.php
@@ -101,7 +101,7 @@ class FSPdf
             }
             
             Model::header('Content-Type','application/pdf');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");
             Model::header('Accept-Ranges','none');
             return Model::isCreated();
         } else {
@@ -295,7 +295,7 @@ class FSPdf
 
             // the file was found
             Model::header('Content-Type','application/pdf');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");   
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");   
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');
             readfile( $this->config['DIR']['files'].'/'.$filePath );

--- a/FS/FSZip/FSZip.php
+++ b/FS/FSZip/FSZip.php
@@ -143,7 +143,7 @@ class FSZip
         if (isset($params['filename'])){
             readfile( $this->config['DIR']['files'].'/'.$filePath );
             Model::header('Content-Type','application/zip');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");
             Model::header('Content-Length',filesize($this->config['DIR']['files'].'/'.$filePath));
             Model::header('Accept-Ranges','none');
             return Model::isCreated();
@@ -187,7 +187,7 @@ class FSZip
 
             // the file was found
             Model::header('Content-Type','application/zip');
-            Model::header('Content-Disposition',"attachment; filename=\"".$params['filename']."\"");  
+            Model::header('Content-Disposition',"filename=\"".$params['filename']."\"");  
             Model::header('Accept-Ranges','none');                                          
             readfile( $this->config['DIR']['files'].'/'.$filePath );
             return Model::isOk();

--- a/UI/Download.php
+++ b/UI/Download.php
@@ -45,7 +45,7 @@ foreach ($types as $type){
 }
 if (isset($_GET['downloadCSV'])) {
     checkPermission(PRIVILEGE_LEVEL::TUTOR);
-    $sid = cleanInput($_GET['downloadCSV']);
+    $sid = $_GET['downloadCSV'];
     $location = $logicURI . '/tutor/user/' . $uid . '/exercisesheet/' . $sid.(isset($status) ? '/status/'.$status : '');
     $result = http_get($location, true);
     echo $result;

--- a/UI/Upload.php
+++ b/UI/Upload.php
@@ -16,7 +16,7 @@ Authentication::checkRights(PRIVILEGE_LEVEL::STUDENT, $cid, $uid, $globalUserDat
 
 $langTemplate='Upload_Controller';Language::loadLanguageFile('de', $langTemplate, 'json', dirname(__FILE__).'/');
 
-if (isset($_POST['action']) && $_POST['action'] == 'submit') {
+if (isset($_POST['action']) && $_POST['action'] === 'submit') {
     // handle uploading files
     $timestamp = time();
 
@@ -159,8 +159,8 @@ if (isset($_POST['action']) && $_POST['action'] == 'submit') {
     ///echo Submission::encodeSubmission($uploadSubmission);return;
 
                         $result = http_post_data($URL, Submission::encodeSubmission($uploadSubmission), true, $message);
-    //echo $result;
-                        if ($message != "201") {
+
+                        if ($message !== 201) {
                             $result = Submission::decodeSubmission($result);
                             $exercise = $key + 1;
                             $errormsg = Language::Get('main','errorUploadSubmission', $langTemplate, array('status'=>$message,'exerciseName'=>$exercise['name']));
@@ -192,8 +192,8 @@ if (isset($_POST['action']) && $_POST['action'] == 'submit') {
                                     
                                     $URL = $serverURI.'/DB/DBChoice/formResult/choice';
                                     $result2 = http_post_data($URL, Choice::encodeChoice($choices), true, $message);
-                                    
-                                        if ($message != "201") {
+
+                                        if ($message !== 201) {
                                             $result2 = Choice::decodeChoice($result2);
                                             $exercise = $key + 1;
                                             $errormsg = Language::Get('main','errorUploadSubmission', $langTemplate, array('status'=>$message,'exerciseName'=>$exercise['name']));

--- a/UI/Upload.php
+++ b/UI/Upload.php
@@ -18,9 +18,6 @@ $langTemplate='Upload_Controller';Language::loadLanguageFile('de', $langTemplate
 
 if (isset($_POST['action']) && $_POST['action'] == 'submit') {
     // handle uploading files
-    /**
-     * @todo don't automatically accept the submission
-     */
     $timestamp = time();
 
     $URL = $databaseURI . '/group/user/' . $uid . '/exercisesheet/' . $sid;

--- a/UI/UploadHistory.php
+++ b/UI/UploadHistory.php
@@ -15,14 +15,16 @@ Authentication::checkRights(PRIVILEGE_LEVEL::STUDENT, $cid, $uid, $globalUserDat
 
 $langTemplate='UploadHistory_Controller';Language::loadLanguageFile('de', $langTemplate, 'json', dirname(__FILE__).'/');
 
-if (isset($_POST['sheetID']))
-    $sid = $_POST['sheetID'];
+if (isset($_POST['sheetID'])){
+    $sid = cleanInput($_POST['sheetID']);
+}
 if (isset($sid)){
     $sheetID = $sid;
     $_POST['sheetID'] = $sid;
 }
-if (isset($_GET['action']) && !isset($_POST['action']))
-    $_POST['action'] = $_GET['action'];
+if (isset($_GET['action']) && !isset($_POST['action'])){
+    $_POST['action'] = cleanInput($_GET['action']);
+}
 
 // updates the selectedSubmissions for the group
 if (isset($_POST['updateSelectedSubmission'])) {
@@ -74,7 +76,7 @@ $uploadHistoryOptions_data['uploadUserID'] = isset($uploadUserID) ? $uploadUserI
 $uploadHistoryOptions_data['sheetID'] = isset($sheetID) ? $sheetID : '';
 
 if (isset($_POST['sortUsers']))
-    $uploadHistoryOptions_data['sortUsers'] = $_POST['sortUsers'];
+    $uploadHistoryOptions_data['sortUsers'] = cleanInput($_POST['sortUsers']);
 
 $user_course_data = $uploadHistoryOptions_data['user'];
 

--- a/UI/css/Notifications.css
+++ b/UI/css/Notifications.css
@@ -54,6 +54,10 @@
     color: #f4ad32;
 }
 
+.warning-color {
+    color: #f4ad32;
+}
+
 .success-simple {
     border: 3px dashed #2DB22D;
     color: #2DB22D;

--- a/UI/css/Notifications.css
+++ b/UI/css/Notifications.css
@@ -45,6 +45,12 @@
     color: #DE3838;
 }
 
+.error-symbol {
+    content:url("../Images/Error.png");
+    width: 17px;
+    height: 17px;
+}
+
 .error-color {
     color: #DE3838;
 }

--- a/UI/include/AccountSettings/ChangePassword.template.html
+++ b/UI/include/AccountSettings/ChangePassword.template.html
@@ -19,6 +19,7 @@
                 // any password yet
                 if (isset($password) && $password != "noPassword") {
             ?>
+            
             <label class="form-field left label bold" for="oldPassword"><?php echo Language::Get('main','oldPassword', $langTemplate); ?>:</label>
             <input class="form-field left text-input" type="password" name="oldPassword"  id="oldPassword" />
             <?php
@@ -28,6 +29,9 @@
             <input class="form-field left text-input" type="password" name="newPassword"  id="newPassword" />
             <label class="form-field left label bold new-line" for="newPasswordRepeat"><?php echo Language::Get('main','newPasswordRepeat', $langTemplate); ?>:</label>
             <input class="form-field left text-input" type="password" name="newPasswordRepeat" id="newPasswordRepeat" />
+            <span class="warning-color">
+                <?php echo Language::Get('main','notification', $langTemplate); ?>
+            </span>
         </div>
     </div> <!-- end: content-body-wrapper -->
 </div> <!-- end: content-element -->

--- a/UI/include/AccountSettings/languages/AccountSettings_ChangePassword_de.json
+++ b/UI/include/AccountSettings/languages/AccountSettings_ChangePassword_de.json
@@ -5,6 +5,7 @@
         "oldPassword": "Altes Passwort",
         "newPassword": "Neues Passwort",
         "newPasswordRepeat": "Neues Passwort wiederholen",
-        "execute": "&auml;ndern"
+        "execute": "&auml;ndern",
+        "notification": "Hinweis: Eventuell muss der Browsercache geleert werden, bevor das neue Passwort verwendet werden kann."
     }
 }

--- a/UI/include/CreateSheet/Processor/Processor.template.php
+++ b/UI/include/CreateSheet/Processor/Processor.template.php
@@ -10,7 +10,7 @@ header('Content-Type: text/html; charset=utf-8');
 
 include_once dirname(__FILE__) . '/../../../../Assistants/Structures.php';
 include_once dirname(__FILE__) . '/../../../../Assistants/Request.php';
-if (file_exists(dirname(__FILE__) . '/../../Config.php')) include_once dirname(__FILE__) . '/../../Config.php';
+if (file_exists(dirname(__FILE__) . '/../../Config.php')) include dirname(__FILE__) . '/../../Config.php';
 
 if (!isset($cid)){
     session_start();

--- a/UI/include/CreateSheet/Subtask.template.php
+++ b/UI/include/CreateSheet/Subtask.template.php
@@ -5,7 +5,7 @@
 header('Content-Type: text/html; charset=utf-8');
 //include_once dirname(__FILE__) . '/../../../Assistants/Structures.php';
 include_once dirname(__FILE__) . '/../../../Assistants/Request.php';
-if (file_exists(dirname(__FILE__) . '/../Config.php')) include_once dirname(__FILE__) . '/../Config.php';
+if (file_exists(dirname(__FILE__) . '/../Config.php')){ include dirname(__FILE__) . '/../Config.php';}
 include_once dirname(__FILE__) . '/../Helpers.php';
 ?>
 

--- a/UI/include/ExerciseSheet/ExerciseSheetStudent.template.html
+++ b/UI/include/ExerciseSheet/ExerciseSheetStudent.template.html
@@ -123,9 +123,15 @@
                                 <?php $fileAddress = (isset($exercise['submission']['file']['address']) ? $exercise['submission']['file']['address'] : ''); ?>
                                 <?php $fileURL = "../FS/FSBinder/{$fileAddress}/{$displayName}";/*{$filesystemURI}*/ ?>
 
-                                <a href="<?php echo $fileURL; ?>" title="<?php echo $displayName; ?>" class="plain" target="_blank">
-                                    <img src="Images/Download.png" />
-                                </a>
+                                <?php if (isset($exercise['submission']['file'])){ ?>
+                                    <a href="<?php echo $fileURL; ?>" title="<?php echo $displayName; ?>" class="plain" target="_blank">
+                                        <img src="Images/Download.png" />
+                                    </a>
+                                <?php } else { ?>
+                                    <span>
+                                        <img src="Images/Error.png" title="<?php echo Language::Get('sheet','invalidSubmission', $langTemplate);?>"/>
+                                    </span>
+                                <?php } ?>
                             <?php if (count($groupMember)>1){
                                     if (isset($exercise['submission']['studentId']) && isset($groupMember[$exercise['submission']['studentId']]['userName'])){
                                         print '('.$groupMember[$exercise['submission']['studentId']]['userName'].')';

--- a/UI/include/ExerciseSheet/languages/ExerciseSheet_de.json
+++ b/UI/include/ExerciseSheet/languages/ExerciseSheet_de.json
@@ -12,6 +12,7 @@
         "points": "P",
         "totalSubmissions": "Einsendungen",
         "submissions": "Einsendungen",
+        "invalidSubmission": "fehlerhafte Einsendung",
         "allSubmissions": "alle Einsendungen",
         "totalStudents": "Studenten",
         "selectedSubmissions": "Einsendungen",

--- a/UI/include/Helpers.php
+++ b/UI/include/Helpers.php
@@ -204,7 +204,7 @@ function MakeInfoButton($helpPath)
     global $externalURI;
     $helpPath = implode('/',func_get_args());
     $URL = "{$externalURI}/DB/CHelp/help/".Language::$selectedLanguage."/{$helpPath}";
-    return "<a href='{$URL}' class='plain image-button exercise-sheet-images' target='popup' onclick=\"window.open('', 'popup', 'width=700,height=600,scrollbars=no,location=no,directories=no,menubar=no,toolbar=no,status=no,resizable=yes')\" title='info' target='_blank'><img src='Images/Info.png' /></a>";
+    return "<a href='{$URL}' class='plain image-button exercise-sheet-images' target='popup' onclick=\"window.open('', 'popup', 'width=700,height=600,scrollbars=yes,location=no,directories=no,menubar=no,toolbar=no,status=no,resizable=yes')\" title='info' target='_blank'><img src='Images/Info.png' /></a>";
 }
 
 /**

--- a/UI/include/Helpers.php
+++ b/UI/include/Helpers.php
@@ -201,9 +201,9 @@ EOF;
 
 function MakeInfoButton($helpPath)
 {
-    global $serverURI;
+    global $externalURI;
     $helpPath = implode('/',func_get_args());
-    $URL = "{$serverURI}/DB/CHelp/help/".Language::$selectedLanguage."/{$helpPath}";
+    $URL = "{$externalURI}/DB/CHelp/help/".Language::$selectedLanguage."/{$helpPath}";
     return "<a class='plain image-button' target='popup' onclick=\"window.open('{$URL}', 'popup', 'width=700,height=600,scrollbars=no,location=yes,directories=yes,menubar=yes,toolbar=yes,status=no,resizable=yes')\" title='info' target='_blank'><img style='width:17px;height:17px' src='Images/Info.png' /></a>";
 }
 

--- a/UI/include/Helpers.php
+++ b/UI/include/Helpers.php
@@ -204,7 +204,7 @@ function MakeInfoButton($helpPath)
     global $externalURI;
     $helpPath = implode('/',func_get_args());
     $URL = "{$externalURI}/DB/CHelp/help/".Language::$selectedLanguage."/{$helpPath}";
-    return "<a href='{$URL}' class='plain image-button exercise-sheet-images' target='popup' onclick=\"window.open('#', 'popup', 'width=700,height=600,scrollbars=no,location=yes,directories=yes,menubar=yes,toolbar=yes,status=no,resizable=yes')\" title='info' target='_blank'><img src='Images/Info.png' /></a>";
+    return "<a href='{$URL}' class='plain image-button exercise-sheet-images' target='popup' onclick=\"window.open('', 'popup', 'width=700,height=600,scrollbars=no,location=no,directories=no,menubar=no,toolbar=no,status=no,resizable=yes')\" title='info' target='_blank'><img src='Images/Info.png' /></a>";
 }
 
 /**

--- a/UI/include/Helpers.php
+++ b/UI/include/Helpers.php
@@ -239,9 +239,9 @@ function cleanInput($input)
 
         if (get_magic_quotes_gpc() == 0) {
             // magic quotes is turned off
-            $input = htmlspecialchars(trim(($input)),ENT_QUOTES, 'UTF-8');     //stripcslashes       
+            $input = htmlspecialchars(trim($input),ENT_QUOTES, 'UTF-8');    
         } else {
-            $input = htmlspecialchars(trim($input), ENT_QUOTES, 'UTF-8');
+            $input = htmlspecialchars(stripslashes(trim($input)), ENT_QUOTES, 'UTF-8');
         }
     }
 

--- a/UI/include/Helpers.php
+++ b/UI/include/Helpers.php
@@ -204,7 +204,7 @@ function MakeInfoButton($helpPath)
     global $externalURI;
     $helpPath = implode('/',func_get_args());
     $URL = "{$externalURI}/DB/CHelp/help/".Language::$selectedLanguage."/{$helpPath}";
-    return "<a class='plain image-button' target='popup' onclick=\"window.open('{$URL}', 'popup', 'width=700,height=600,scrollbars=no,location=yes,directories=yes,menubar=yes,toolbar=yes,status=no,resizable=yes')\" title='info' target='_blank'><img style='width:17px;height:17px' src='Images/Info.png' /></a>";
+    return "<a href='{$URL}' class='plain image-button exercise-sheet-images' target='popup' onclick=\"window.open('#', 'popup', 'width=700,height=600,scrollbars=no,location=yes,directories=yes,menubar=yes,toolbar=yes,status=no,resizable=yes')\" title='info' target='_blank'><img src='Images/Info.png' /></a>";
 }
 
 /**

--- a/UI/include/MarkingTool/MarkingTool.template.html
+++ b/UI/include/MarkingTool/MarkingTool.template.html
@@ -99,7 +99,7 @@ if (isset($GroupNotificationElements)) {
                     </span>
                         
                     <?php
-                        print '<span class="very-very-short left">';
+                        print '<span class="very-short left">';
                         print '<input class="form-field text-input very-very-short" placeholder="'.Language::Get('main','points', $langTemplate).'" name="';
                         print 'exercises[' . $leaderID . '][' . $eid . '][points]" value="';
                         print isset($exercise['submission']['marking']['points']) ? $exercise['submission']['marking']['points'] : '';
@@ -174,6 +174,10 @@ if (isset($GroupNotificationElements)) {
                                         print '" class="plain" target="_blank">';
                                         print '<img src="Images/Download.png" />';
                                         print '</a>';
+                                    } elseif (!isset($exercise['submission']['file'])){
+                                        print '<span class ="">';
+                                        print '<img src="Images/Error.png" title="'.Language::Get('main','invalidSubmission', $langTemplate).'"/>';
+                                        print '</span>';
                                     }
                                 }
                             }

--- a/UI/include/MarkingTool/languages/MarkingTool_de.json
+++ b/UI/include/MarkingTool/languages/MarkingTool_de.json
@@ -4,6 +4,7 @@
         "points": "Punkte",
         "tutorComment": "Ihr Kommentar",
         "studentComment": "Komm.",
-        "additionalMembers": "Weitere Gruppenmitglieder"
+        "additionalMembers": "Weitere Gruppenmitglieder",
+        "invalidSubmission": "fehlerhafte Einsendung"
     }
 }

--- a/UI/include/Upload/Upload.template.html
+++ b/UI/include/Upload/Upload.template.html
@@ -77,6 +77,7 @@
                             <?php $date = $sub['date']; ?>
                             <?php $fileURL = "../FS/FSBinder/{$fileAddress}/{$displayName}"; /*{$filesystemURI}*/?>
 
+                            <?php if (isset($file)){ ?>
                             <a href="<?php echo $fileURL; ?>"
                                title="<?php echo $displayName; ?>"
                                class="left body-option-color"
@@ -86,6 +87,15 @@
                                 <?php echo formatBytes($file['fileSize']); ?>
                                 )
                             </a>
+                            <?php } else { ?>
+                            <span class ="left error-color">
+                                <img src="Images/Error.png" class='exercise-sheet-images' title="<?php echo Language::Get('submission','invalidSubmission', $langTemplate);?>"/>
+                                <?php echo Language::Get('submission','invalidSubmission', $langTemplate); ?> (
+                                <?php echo date('d.m.Y  -  H:i', $date); ?>
+                                )
+                            </span>
+                            <?php } ?>
+                            
                             <?php if (count($groupMember)>1){
                                 if (isset($exercise['selectedSubmission']['studentId']) && isset($groupMember[$exercise['selectedSubmission']['studentId']]['userName'])){
                                     print '('.$groupMember[$exercise['selectedSubmission']['studentId']]['userName'].')';

--- a/UI/include/Upload/languages/Student_Upload_de.json
+++ b/UI/include/Upload/languages/Student_Upload_de.json
@@ -7,6 +7,7 @@
         "execute": "alle absenden",
         "downloadCurrentSubmission": "Herunterladen",
         "currentStudentComment": "Kommentar der bisherigen Einsendung",
+        "invalidSubmission": "fehlerhafte Einsendung",
         "comment": "Kommentar",
         "file": "Datei (max. $maxFileSize)",
         "exercise": "AUFGABE",

--- a/UI/include/UploadHistory/UploadHistory.template.html
+++ b/UI/include/UploadHistory/UploadHistory.template.html
@@ -81,7 +81,7 @@ echo '<span class="content-body-wrapper">';
                             // prints the submission date
                             $selected = (isset($submission['selectedForGroup']) && $submission['selectedForGroup']==1) ? true : false;
                             echo '<div class="form-field left bold new-line '. ($selected ? 'critical-color' : '') .'">';
-                            print date('d.m.Y  -  H:i', $submission['date']);
+                            print date('d.m.Y  -  H:i:s', $submission['date']);
                             if (!$selected){ 
                             $obj=array("id"=>$submission['id'], "leaderId"=>$submission['leaderId'], "exerciseId"=>$submission['exerciseId']);
                                 if (count($groupMember)==1 || $_POST['userID']==$group['leader']['id'] || $courseStatus>=1 /* PRIVILEGE_LEVEL::TUTOR */){

--- a/UI/include/UploadHistory/UploadHistory.template.html
+++ b/UI/include/UploadHistory/UploadHistory.template.html
@@ -109,7 +109,7 @@ echo '<span class="content-body-wrapper">';
                             print '<span class="wider left '.($selected ? 'bold critical-color' : 'body-option-color').'">';
                             print '<div class="exercise-sheet-images">';
                             
-                            if (isset($submission['file']) && (!isset($submission['file']['hideFile']) || !$submission['file']['hideFile'])){
+                            if (isset($submission['file']) && (!isset($submission['hideFile']) || !$submission['hideFile'])){
                                 $displayName = (isset($submission['file']['displayName']) ? $submission['file']['displayName'] : '');
                                 $fileAddress = (isset($submission['file']['address']) ? $submission['file']['address'] : '');
                                 $fileSize = (isset($submission['file']['fileSize']) ? $submission['file']['fileSize'] : 0);
@@ -118,6 +118,11 @@ echo '<span class="content-body-wrapper">';
                                 print '        <img src="Images/Download.png" />';
                                 print ' (' . formatBytes($fileSize) . ') ';
                                 print '</a>';
+                            } elseif(!isset($submission['file'])) {
+                                print '<span class ="">';
+                                print '<img src="Images/Error.png" title="'.Language::Get('main','invalidSubmission', $langTemplate).'"/>';
+                                print ' (' . formatBytes(0) . ') ';
+                                print '</span>';
                             }
                             
                             if (isset($submission['marking']['id']) && ($courseStatus>=1 /* PRIVILEGE_LEVEL::TUTOR */ || (isset($isExpired) && $isExpired))){  

--- a/UI/include/UploadHistory/languages/UploadHistory_de.json
+++ b/UI/include/UploadHistory/languages/UploadHistory_de.json
@@ -4,6 +4,7 @@
         "notAccepted": "nicht akzeptiert",
         "uncorrected": "unkorrigiert",
         "removed": "gel&ouml;scht",
-        "noSubmissions": "Keine Einsendungen vorhanden."
+        "noSubmissions": "Keine Einsendungen vorhanden.",
+        "invalidSubmission": "fehlerhafte Einsendung"
     }
 }

--- a/UI/languages/Upload_Controller_de.json
+++ b/UI/languages/Upload_Controller_de.json
@@ -10,6 +10,8 @@
         "expiredExercisePerion": "Der Übungszeitraum ist am $endDate abgelaufen!",
         "backToCourse": "zur Veranstaltung",
         "errorUploadSubmissionSymbols": " $status: Aufgabe $exerciseName konnte nicht hochgeladen werden. <br/> Der Dateiname enthält unerlaubte Zeichen. <br/> Verwenden Sie nur a-z, A-Z, 0-9 und ._-",
-        "errorUploadSubmissionFileToLarge": " $status: Aufgabe $exerciseName konnte nicht hochgeladen werden. <br/> Die Datei war zu groß (max. $maxFileSize)."
+        "errorUploadSubmissionFileToLarge": " $status: Aufgabe $exerciseName konnte nicht hochgeladen werden. <br/> Die Datei war zu groß (max. $maxFileSize).",
+        "errorInvalidExerciseId": " $status: Die verwendete Aufgabennummer konnte nicht zugeordnet werden.",
+        "errorInvalidSheetId": "Die verwendete ID der Übungsserie konnte nicht zugeordnet werden."
     }
 }

--- a/generateDocs.php
+++ b/generateDocs.php
@@ -106,4 +106,3 @@ if (!file_exists($path.'/info/de.md')){
 // wir haben es geschafft
 echo "fertig....<br>";
 echo date("d.m.Y H:i:s",time())."<br>";
-?>

--- a/generatePath.php
+++ b/generatePath.php
@@ -133,4 +133,3 @@ function umlaute($text){
 // wir haben es geschafft
 echo "fertig....<br>";
 echo date("d.m.Y H:i:s",time())."<br>";
-?>

--- a/install/css/format.css
+++ b/install/css/format.css
@@ -20,6 +20,7 @@ h2 {font-size: 125%;}
 .v_c {background-color: #cccccc; color: #000000;text-align: center;}
 .vr {background-color: #cccccc; text-align: right; color: #000000;}
 .error {color: #ff0000;text-align: center;font-weight: bold;}
+.warning {color: #DF7401;text-align: center;font-weight: bold;}
 .error_light {color: #ff0000;word-break: normal;}
 .tiny {font-size: 90%;}
 .bold {font-weight: bold;}

--- a/install/include/Design.php
+++ b/install/include/Design.php
@@ -159,20 +159,20 @@ class Design
      */
     public static function erstelleEingabezeile($console, &$variable, $variablenName, $default, $save=false)
     {
-        if ($save == true && $variable == null){
+        if ($save == true && $variable === null){
             $variable = Einstellungen::Get($variablenName, $default);
         } 
         
-        if ($save == true && $variable != null)
+        if ($save == true && $variable !== null)
             Einstellungen::Set($variablenName, $variable);
             
-        if ($variable == null)
+        if ($variable === null)
             $variable = $default;
         
         $result = '';
         
         if (!$console)
-            $result = "<input style='width:100%' type='text' name='{$variablenName}' value='".($variable != null? $variable : $default)."'>";
+            $result = "<input style='width:100%' type='text' name='{$variablenName}' value='".(isset($variable) ? $variable : $default)."'>";
         
         return $result;
     }
@@ -238,20 +238,21 @@ class Design
      */
     public static function erstelleVersteckteEingabezeile($console, &$variable, $variablenName, $default, $save=false)
     {
-        if ($save == true && $variable == null){
+        if ($save == true && $variable === null){
             $variable = Einstellungen::Get($variablenName, $default);
         } 
         
-        if ($save == true && $variable != null)
+        if ($save == true && $variable !== null){
             Einstellungen::Set($variablenName, $variable);
+        }
             
-        if ($variable == null)
+        if ($variable === null)
             $variable = $default;
         
         $result = '';
         
         if (!$console)
-            $result = "<input type='hidden' name='{$variablenName}' value='".($variable != null ? $variable : $default)."'>";
+            $result = "<input type='hidden' name='{$variablenName}' value='".(isset($variable) ? $variable : $default)."'>";
         
         return $result;
     }
@@ -323,6 +324,16 @@ class Design
      */
     public static function erstellePasswortzeile($console, $variable, $variablenName, $default, $save=false)
     {
+        if ($save == true && $variable === null){
+            $variable = Einstellungen::Get($variablenName, $default);
+        } 
+        
+        if ($save == true && $variable !== null)
+            Einstellungen::Set($variablenName, $variable);
+            
+        if ($variable === null)
+            $variable = $default;
+        
         $result = '';
         
         if (!$console)

--- a/install/include/Einstellungen.php
+++ b/install/include/Einstellungen.php
@@ -459,7 +459,7 @@ class Einstellungen
      */
     public static function Get($varName, $default)
     {
-        if (Einstellungen::$konfiguration != null && isset(Einstellungen::$konfiguration[$varName])){
+        if (Einstellungen::$konfiguration !== null && isset(Einstellungen::$konfiguration[$varName])){
             return Einstellungen::$konfiguration[$varName];
         } else
             return $default;
@@ -475,7 +475,7 @@ class Einstellungen
      */
     public static function GetDirekt($konfiguration, $varName, $default)
     {
-        if ($konfiguration != null && isset($konfiguration[$varName])){
+        if ($konfiguration !== null && isset($konfiguration[$varName])){
             return $konfiguration[$varName];
         } else
             return $default;

--- a/install/install.php
+++ b/install/install.php
@@ -551,12 +551,32 @@ class Installer
                 echo "<table border='0'>";
                 foreach(Einstellungen::$segments as $segs){
                     if (!is_callable("{$segs}::getSettingsBar")) continue;
+                    
                     $settings = $segs::getSettingsBar($data);
                     if (count($settings)>0){
                         foreach ($settings as $key => $values){
+                            // values entspricht
+                            // [0] = Name/Überschift
+                            // [1] = Wert/Zustand
+                            // [2] = Standardwert mit dem verglichen werden soll (Gleichheit wird zum Warnhinweis) (null = Nein)
+                            // [3] = Fehler soll angezeigt werden (true = Fehler, false = sonst)
+                            
                             if (!isset($values[0]) || !isset($values[1])) continue;
+                            $add='';
+                            $addText='';
+                            if (isset($values[2])){
+                                // Standardwert soll geprüft werden
+                                if ($values[1] == $values[2]){
+                                    $add = 'class="warning"';
+                                    $addText = '&lt;&lt;'.Language::Get('main','warnDefault')."&gt;&gt;<br/>";
+                                }
+                            } elseif (isset($values[3]) && $values[3] == true) {
+                                $add = 'class="error"';
+                                $addText = '&lt;&lt;'.Language::Get('main','errorValue')."&gt;&gt;<br/>";
+                            }
+                            
                             echo "<tr><td class='e'>".$values[0]."</td></tr>";
-                            echo "<tr><td>".$values[1]."</td></tr>";
+                            echo "<tr><td><span {$add}>".$addText."</span>".$values[1]."</td></tr>";
                             echo "<tr><th></th></tr>"; 
                         }
                     }

--- a/install/languages/de.ini
+++ b/install/languages/de.ini
@@ -32,6 +32,8 @@ getAccess = "Betreten"
 changeMasterPassword = "Ändern"
 actions = "Aktionen"
 emptyMasterPassword = "Geben Sie ein Passwort für diese Konfiguration ein"
+warnDefault = "Standardwert"
+errorValue = "Fehler"
 
 line = "Zeile"
 

--- a/install/segments/BenutzerschnittstelleEinrichten.php
+++ b/install/segments/BenutzerschnittstelleEinrichten.php
@@ -12,6 +12,14 @@ class BenutzerschnittstelleEinrichten
     
     public static $onEvents = array('install'=>array('name'=>'UIConf','event'=>array('actionInstallUIConf','install', 'update')));
     
+    public static function getSettingsBar(&$data)
+    {
+        $defs = self::getDefaults();
+        return array(
+                     'siteKey' => array(Language::Get('userInterface','siteKey'), $data['UI']['siteKey'], $defs['siteKey'][1])                   
+                     );
+    }
+    
     public static function getDefaults()
     {
         return array(

--- a/install/segments/BenutzerschnittstelleEinrichten.php
+++ b/install/segments/BenutzerschnittstelleEinrichten.php
@@ -76,7 +76,8 @@ class BenutzerschnittstelleEinrichten
         $text[]='$logicURI = $serverURI . "/logic/LController";';
         $text[]='$filesystemURI = $serverURI . "/FS/FSControl";';
         $text[]='$getSiteURI = $serverURI . "/logic/LGetSite";';
-        $text[]='$globalSiteKey'. " = '{$data['UI']['siteKey']}';";        
+        $text[]='$globalSiteKey'. " = '{$data['UI']['siteKey']}';"; 
+        $text[]='$externalURI'. " = '{$data['PL']['urlExtern']}';";       
         
         $text = implode("\n",$text);
         if (!@file_put_contents(dirname(__FILE__).'/../'.$file,$text)){ $fail = true;$error='UI-Konfigurationsdatei, kein Schreiben möglich!';return null;} 

--- a/install/segments/DatenbankInformationen.php
+++ b/install/segments/DatenbankInformationen.php
@@ -14,11 +14,12 @@ class DatenbankInformationen
     
     public static function getSettingsBar(&$data)
     {
+        $defs = self::getDefaults();
         return array(
-                     'db_name' => array(Language::Get('database_informations','db_name'), $data['DB']['db_name']),
-                     'db_path' => array(Language::Get('database_informations','db_path'), $data['DB']['db_path']),
-                     'db_user' => array(Language::Get('databaseAdmin','db_user'), $data['DB']['db_user']),
-                     'db_user_operator' => array(Language::Get('databasePlatformUser','db_user_operator'), $data['DB']['db_user_operator'])
+                     'db_name' => array(Language::Get('database_informations','db_name'), $data['DB']['db_name'], $defs['db_name'][1]),
+                     'db_path' => array(Language::Get('database_informations','db_path'), $data['DB']['db_path'], $defs['db_path'][1]),
+                     'db_user' => array(Language::Get('databaseAdmin','db_user'), $data['DB']['db_user'], $defs['db_user'][1]),
+                     'db_user_operator' => array(Language::Get('databasePlatformUser','db_user_operator'), $data['DB']['db_user_operator'], $defs['db_user_operator'][1])
                      );
     }
     

--- a/install/segments/Grundinformationen.php
+++ b/install/segments/Grundinformationen.php
@@ -13,12 +13,13 @@ class Grundinformationen
     
     public static function getSettingsBar(&$data)
     {
+        $defs = self::getDefaults();
         return array(
-                     'url' => array(Language::Get('general_informations','url'), $data['PL']['url']),
-                     'localPath' => array(Language::Get('general_informations','localPath'), $data['PL']['localPath']),
-                     'urlExtern' => array(Language::Get('general_informations','urlExtern'), $data['PL']['urlExtern']),
-                     'temp' => array(Language::Get('general_informations','temp'), $data['PL']['temp']),
-                     'files' => array(Language::Get('general_informations','files'), $data['PL']['files'])                     
+                     'url' => array(Language::Get('general_informations','url'), $data['PL']['url'], $defs['url'][1]),
+                     'localPath' => array(Language::Get('general_informations','localPath'), $data['PL']['localPath'], $defs['localPath'][1]),
+                     'urlExtern' => array(Language::Get('general_informations','urlExtern'), $data['PL']['urlExtern'], $defs['urlExtern'][1]),
+                     'temp' => array(Language::Get('general_informations','temp'), $data['PL']['temp'], $defs['temp'][1]),
+                     'files' => array(Language::Get('general_informations','files'), $data['PL']['files'], $defs['files'][1])                     
                      );
     }
     

--- a/install/segments/Komponenten.php
+++ b/install/segments/Komponenten.php
@@ -247,7 +247,6 @@ class Komponenten
        
         // inits all components
         $result = Request::get($data['PL']['url'].'/'.$url. '/definition/send',array(),'');
-        //echo $result['content'];
         if (isset($result['content']) && isset($result['status'])){
 
             // component routers

--- a/logic/LSamples/LSamples.php
+++ b/logic/LSamples/LSamples.php
@@ -43,5 +43,3 @@ class LSamples
     }
 }
 
- 
-?>

--- a/logic/LSamples/index.php
+++ b/logic/LSamples/index.php
@@ -12,4 +12,3 @@ require_once ( dirname( __FILE__ ) . '/LSamples.php' );
 include_once ( '../../Assistants/CConfig.php' );
 
 new LSamples();
-?>

--- a/logic/LTutor/LTutor.php
+++ b/logic/LTutor/LTutor.php
@@ -15,6 +15,7 @@ include_once dirname(__FILE__) . '/../../Assistants/Structures/Transaction.php';
 include_once dirname(__FILE__) . '/../../Assistants/Structures/Platform.php';
 include_once dirname(__FILE__) . '/../../Assistants/Structures/File.php';
 include_once dirname(__FILE__) . '/../../Assistants/Language.php';
+include_once dirname(__FILE__) . '/../../Assistants/LArraySorter.php';
 
 \Slim\Slim::registerAutoloader();
 
@@ -951,7 +952,10 @@ class LTutor
                 if (isset($marking['status']) && $marking['status'] == $status)
                     $marks[] = $marking;
             $markings=$marks;
-        }            
+        }
+        
+        // sortiere die Korrekturen innerhalb dieser Liste
+        $markings = LArraySorter::orderby($markings, 'id', SORT_ASC);
 
         $answer = $this->generateTutorArchive($userid, $sheetid, $markings);
         $this->app->response->setStatus($answer['status']);

--- a/logic/LTutor/LTutor.php
+++ b/logic/LTutor/LTutor.php
@@ -1059,7 +1059,7 @@ class LTutor
                             fclose($csv);
                             $this->deleteDir($tempDir);
                             $this->app->response->setStatus(409);
-                            $errors[] = Language::Get('main','unknownMarkindID', self::$langTemplate, array('csvFile'=>$csvFile,'markingId'=>htmlspecialchars(trim(($markingId)),ENT_QUOTES, 'UTF-8')));
+                            $errors[] = Language::Get('main','unknownMarkingID', self::$langTemplate, array('csvFile'=>$csvFile,'markingId'=>htmlspecialchars(trim(($markingId)),ENT_QUOTES, 'UTF-8')));
                             $this->app->response->setBody(json_encode($errors));
                             $this->app->stop();
                         }

--- a/logic/LTutor/LTutor.php
+++ b/logic/LTutor/LTutor.php
@@ -976,6 +976,16 @@ class LTutor
         
         // check if csv file exists
         if (file_exists($files.'/Liste.csv')){
+            // UTF8 is required
+            $text = file_get_contents($files.'/Liste.csv');
+            if (mb_detect_encoding($text, 'UTF-8', true)=== false){
+                $errors[] = 'Liste.csv: It is required that you store all your data in Unicode format (UTF-8)';
+                $this->deleteDir($tempDir);
+                $this->app->response->setStatus(409);
+                $this->app->response->setBody(json_encode($errors));
+                $this->app->stop();
+            }
+            
             $csv = fopen($files.'/Liste.csv', "r");
             
             if (($transactionId = fgetcsv($csv,0,';')) === false){

--- a/logic/LTutor/LTutor.php
+++ b/logic/LTutor/LTutor.php
@@ -14,6 +14,7 @@ include_once dirname(__FILE__) . '/../../Assistants/CConfig.php';
 include_once dirname(__FILE__) . '/../../Assistants/Structures/Transaction.php';
 include_once dirname(__FILE__) . '/../../Assistants/Structures/Platform.php';
 include_once dirname(__FILE__) . '/../../Assistants/Structures/File.php';
+include_once dirname(__FILE__) . '/../../Assistants/Language.php';
 
 \Slim\Slim::registerAutoloader();
 
@@ -29,6 +30,9 @@ class LTutor
      */
     private $_conf=null;
     private $config = array();
+    
+    
+    private static $langTemplate='LTutor';
 
     /**
      * @var string $_prefix the prefix, the class works with
@@ -99,6 +103,8 @@ class LTutor
                                            dirname(__FILE__).'/config.ini',
                                            TRUE
                                            ); 
+
+        Language::loadLanguageFile('de', self::$langTemplate, 'json', dirname(__FILE__).'/');
 
         /**
          *Set the Logiccontroller-URL
@@ -953,7 +959,9 @@ class LTutor
     }
 
     public function uploadZip($userid, $courseid)
-    {                        
+    {           
+        $csvFile = 'Liste.csv';
+    
         // error array of strings
         $errors = array();
         LTutor::generatepath($this->config['DIR']['temp']);
@@ -975,11 +983,11 @@ class LTutor
         $files = $tempDir.'/files';
         
         // check if csv file exists
-        if (file_exists($files.'/Liste.csv')){
+        if (file_exists($files.'/'.$csvFile)){
             // UTF8 is required
-            $text = file_get_contents($files.'/Liste.csv');
+            $text = file_get_contents($files.'/'.$csvFile);
             if (mb_detect_encoding($text, 'UTF-8', true)=== false){
-                $errors[] = 'Liste.csv: It is required that you store all your data in Unicode format (UTF-8)';
+                $errors[] = Language::Get('main','utf8Required', self::$langTemplate, array('csvFile'=>$csvFile));
                 $this->deleteDir($tempDir);
                 $this->app->response->setStatus(409);
                 $this->app->response->setBody(json_encode($errors));
@@ -992,7 +1000,7 @@ class LTutor
                 fclose($csv);
                 $this->deleteDir($tempDir);
                 $this->app->response->setStatus(409);
-                $errors[] = 'empty .csv file';
+                $errors[] = Language::Get('main','emptyCSV', self::$langTemplate, array('csvFile'=>$csvFile));
                 $this->app->response->setBody(json_encode($errors));
                 $this->app->stop();
             }
@@ -1032,7 +1040,7 @@ class LTutor
                             (isset($currectOrder['TUTORCOMMENT']) && !isset($row[$currectOrder['TUTORCOMMENT']])) ||
                             (isset($currectOrder['OUTSTANDING']) && !isset($row[$currectOrder['OUTSTANDING']])) ||
                             (isset($currectOrder['STATUS']) && !isset($row[$currectOrder['STATUS']]))){
-                            $errors[] = 'invalid Liste.csv';
+                            $errors[] = Language::Get('main','invalidCSV', self::$langTemplate, array('csvFile'=>$csvFile));
                             fclose($csv);
                             $this->deleteDir($tempDir);
                             $this->app->response->setStatus(409);
@@ -1051,11 +1059,10 @@ class LTutor
                             fclose($csv);
                             $this->deleteDir($tempDir);
                             $this->app->response->setStatus(409);
-                            $errors[] = "unknown ID: {$markingId}";
+                            $errors[] = Language::Get('main','unknownMarkindID', self::$langTemplate, array('csvFile'=>$csvFile,'markingId'=>htmlspecialchars(trim(($markingId)),ENT_QUOTES, 'UTF-8')));
                             $this->app->response->setBody(json_encode($errors));
                             $this->app->stop();
                         }
-                        ///var_dump($transaction['markings'][$markingId]);
                         $markingData = $transaction['markings'][$markingId];
                         
                         // checks whether the points are less or equal to the maximum points
@@ -1130,23 +1137,11 @@ class LTutor
                                                              $file==null ? 1 : 0
                                                              );
                             $marking->setFile($file);
-                            
-                            /*array(
-                                    'id' => ($markingId<0 ? null : $markingId),
-                                    'points' => $points,
-                                    'outstanding' => isset($currectOrder['OUTSTANDING']) ? $row[$currectOrder['OUTSTANDING']] : null,
-                                    'tutorId' => $userid,
-                                    'tutorComment' => isset($currectOrder['TUTORCOMMENT']) ? $row[$currectOrder['TUTORCOMMENT']] : null,
-                                    'file' => $file,
-                                    'status' => isset($currectOrder['STATUS']) ? $row[$currectOrder['STATUS']] : null,
-                                    'date' => time(),
-                                    'hideFile' => 
-                                    );*/
 
                             $markings[] = $marking;
 
                         } else { //if file with this markingid not exists
-                            $errors[] = 'File does not exist: '.$markingFile;
+                            $errors[] = Language::Get('main','unknownMarkingPath', self::$langTemplate, array('csvFile'=>$csvFile, 'markingFile'=>htmlspecialchars(trim(($markingFile)),ENT_QUOTES, 'UTF-8')));
                             fclose($csv);
                             $this->deleteDir($tempDir);
                             $this->app->response->setStatus(409);
@@ -1159,8 +1154,6 @@ class LTutor
                 $mark = @json_encode($markings);
                 
                 if ($mark !== false){
-                
-                    ///echo json_encode($markings); return;
                     //request to database to edit the markings
                     $result = Request::routeRequest(
                                                     'POST',
@@ -1173,19 +1166,19 @@ class LTutor
                                                 
                     /// TODO: prüfen ob jede hochgeladen wurde
                     if ($result['status'] != 201) {
-                        $errors[] = 'send markings failed';
+                        $errors[] = Language::Get('main','errorSendMarkings', self::$langTemplate, array('csvFile'=>$csvFile));
                     }
                 } else {
-                    $errors[] = 'invalid input';
+                    $errors[] = Language::Get('main','encodeMarkingsError', self::$langTemplate, array('csvFile'=>$csvFile));
                 }
                 
             } else {
-                $errors[] = 'no transaction data';
+                $errors[] = Language::Get('main','noTransactionData', self::$langTemplate, array('csvFile'=>$csvFile));
             }
             
             fclose($csv);
         } else { // if csv file does not exist
-            $errors[] = '.csv file does not exist in uploaded zip-Archiv';
+            $errors[] = Language::Get('main','missingCSV', self::$langTemplate, array('csvFile'=>$csvFile));
         }
         $this->deleteDir($tempDir);
 

--- a/logic/LTutor/languages/LTutor_de.json
+++ b/logic/LTutor/languages/LTutor_de.json
@@ -1,0 +1,13 @@
+{
+    "main": {
+        "utf8Required": " $csvFile: Die Daten m&uuml;ssen UTF-8 kodiert sein.",
+        "emptyCSV": " $csvFile: Die Datei ist leer.",
+        "invalidCSV": " $csvFile: Die Spalten passen nicht zum Inhalt (eventuell wurden die Spaltenbezeichner gel&ouml;scht oder verwechselt).",
+        "unknownMarkingID": " $csvFile: Es wurde eine unbekannte Korrekturnummer gefunden ($markingId).",
+        "unknownMarkingPath": " $csvFile: Die Korrekturdatei konnte nicht gefunden werden ($markingFile).",
+        "errorSendMarkings":" $csvFile: Die Korrekturdaten konnten nicht gespeichert werden.",
+        "encodeMarkingsError":" $csvFile: Die Korrekturdaten konnten nicht interpretiert werden.",
+        "noTransactionData":" $csvFile: Die ermittelte Transaktionsnummer konnte nicht zugeordnet werden.<br/><br/>Hinweise:<br/>1. Das Korrekturarchiv muss von Ihnen erstellt worden sein.<br/>2. Sie m&uuml;ssen das Korrekturarchiv in der richtigen Veranstaltung hochladen.<br/>3. Die erste Zeile der $csvFile muss die Transaktionsnummer enthalten.<br/>4. Die Transaktionsnummern sind 30 Tage g&uuml;ltig.",
+        "missingCSV":" $csvFile: Die CSV-Datei konnte nicht, im Archiv, gefunden werden."
+    }
+}


### PR DESCRIPTION
#103 DBTransaction-Fehlermeldungen exakter machen (404 ist nicht genug)
#193 TutorUpload, UTF8 Fehlermeldung anzeigen
#194 Dateifehler anzeigen, für Einsendungen mit hideFile=0 und file=null
#197 Hilfeseiten enthalten falsche URL
#202 Einsendungsverlauf, beim Datum die Sekunden anzeigen
![d](https://cloud.githubusercontent.com/assets/7592615/12589393/c06a1e08-c45d-11e5-90b8-d3bf5d7ae1c6.png)

#203 Installationsassistent, SiteKey als Seiteninfo (rechts)
![a](https://cloud.githubusercontent.com/assets/7592615/12589370/a7be72e6-c45d-11e5-874a-b4db561a4a97.png)

#204 Installationsassistent, Hinweis wenn SiteKey = default
![b](https://cloud.githubusercontent.com/assets/7592615/12589379/acee36d4-c45d-11e5-8dde-94bf24155d73.png)

#205 Installationsassistent, externe URL korrekt verarbeiten
#206 Installationsassistent, externe URL in Config.php eintragen
#207 Account-ChangePassword, Hinweis einfügen
![c](https://cloud.githubusercontent.com/assets/7592615/12589389/ba6cbab0-c45d-11e5-8667-ea338ffd5537.png)

#208 DBMarking, abgerufene Elemente sind nach Submission::ID und nicht nach Marking::ID geordnet
#210 FSFile und FSBinder, korrekten mime-type zurückgeben